### PR TITLE
Update Travis scripts not fail when skipping deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,30 +8,32 @@ services:
 jobs:
   include:
   - stage: Test Backend Locally
-    before_script: cd backend; yarn; yarn init-local-db; yarn local-drop-rebuild
-    script: cd backend; yarn postgraphql-local & yarn test
+      before_script: cd backend; yarn; yarn init-local-db; yarn local-drop-rebuild
+      script: cd backend; yarn postgraphql-local & yarn test
   - stage: Test Frontend Locally
-    before_script: cd backend; yarn; yarn init-local-db; yarn local-drop-rebuild;
-    script: cd backend; yarn postgraphql-local & cd ../frontend; yarn; yarn get-schema;
-      yarn test
+      before_script: cd backend; yarn; yarn init-local-db; yarn local-drop-rebuild;
+      script: cd backend; yarn postgraphql-local & cd ../frontend; yarn; yarn get-schema; yarn test
   - stage: Deploy Backend to AWS
-    # allow_failure: ${[ -z "$AWS_ACCESS_KEY_ID" ] && echo true || echo false}
-    allow_failure: true
-    before_script: npm install -g serverless
-    script: cd backend; yarn; yarn rebuild-and-deploy
+      before_script: 
+        - 'if [ -z "$AWS_ACCESS_KEY_ID" ]; then 
+            travis_terminate 1;
+          else
+            npm install -g serverless;
+          fi'
+      script: cd backend; yarn; yarn rebuild-and-deploy
   - stage: Test backend against AWS endpoint
-    before_script: npm install -g serverless
-    script: cd backend; yarn; yarn test-on-aws
-    after_script: cd backend; yarn; yarn rebuild-and-deploy
+      before_script: npm install -g serverless
+      script: cd backend; yarn; yarn test-on-aws
+      after_script: cd backend; yarn; yarn rebuild-and-deploy
   - stage: Deploy frontend to s3
-    script: cd frontend; yarn; yarn build
-    deploy:
-      provider: s3
-      access_key_id: "$AWS_ACCESS_KEY_ID"
-      secret_access_key: "$AWS_SECRET_ACCESS_KEY"
-      bucket: "$S3_BUCKET"
-      skip_cleanup: true
-      local_dir: build
-      acl: public_read
-      on:
-        all_branches: true
+      script: cd frontend; yarn; yarn build
+      deploy:
+        provider: s3
+        access_key_id: "$AWS_ACCESS_KEY_ID"
+        secret_access_key: "$AWS_SECRET_ACCESS_KEY"
+        bucket: "$S3_BUCKET"
+        skip_cleanup: true
+        local_dir: build
+        acl: public_read
+        on:
+          all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ jobs:
     script: cd backend; yarn postgraphql-local & cd ../frontend; yarn; yarn get-schema;
       yarn test
   - stage: Deploy Backend to AWS
+    before_script: skip
     before_script: npm install -g serverless
     script: cd backend; yarn; yarn rebuild-and-deploy
   - stage: Test backend against AWS endpoint

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ services:
 jobs:
   include:
   - stage: Test Backend Locally
-      before_script: cd backend; yarn; yarn init-local-db; yarn local-drop-rebuild
-      script: cd backend; yarn postgraphql-local & yarn test
+    before_script: cd backend; yarn; yarn init-local-db; yarn local-drop-rebuild
+    script: cd backend; yarn postgraphql-local & yarn test
   - stage: Test Frontend Locally
       before_script: cd backend; yarn; yarn init-local-db; yarn local-drop-rebuild;
       script: cd backend; yarn postgraphql-local & cd ../frontend; yarn; yarn get-schema; yarn test

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,11 +33,11 @@ jobs:
     script: cd backend; yarn; yarn test-on-aws
     after_script: cd backend; yarn; yarn rebuild-and-deploy
   - stage: Deploy frontend to s3
-      before_script: 
-      - 'if [ -z "$AWS_ACCESS_KEY_ID" ]; then
-          echo "AWS Credentials not set. Skipping deployment.";
-          travis_terminate 0;
-        fi'
+    before_script: 
+    - 'if [ -z "$AWS_ACCESS_KEY_ID" ]; then
+        echo "AWS Credentials not set. Skipping deployment.";
+        travis_terminate 0;
+      fi'
     script: cd frontend; yarn; yarn build
     deploy:
       provider: s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,19 +16,28 @@ jobs:
   - stage: Deploy Backend to AWS
     before_script: 
       - 'if [ -z "$AWS_ACCESS_KEY_ID" ]; then
-          tput bold;
           echo "AWS Credentials not set. Skipping deployment.";
-          tput sgr0;
           travis_terminate 0;
         else
           npm install -g serverless;
         fi'
     script: cd backend; yarn; yarn rebuild-and-deploy
   - stage: Test backend against AWS endpoint
-    before_script: npm install -g serverless
+    before_script: 
+      - 'if [ -z "$AWS_ACCESS_KEY_ID" ]; then
+          echo "AWS Credentials not set. Skipping tests.";
+          travis_terminate 0;
+        else
+          npm install -g serverless;
+        fi'
     script: cd backend; yarn; yarn test-on-aws
     after_script: cd backend; yarn; yarn rebuild-and-deploy
   - stage: Deploy frontend to s3
+      before_script: 
+      - 'if [ -z "$AWS_ACCESS_KEY_ID" ]; then
+          echo "AWS Credentials not set. Skipping deployment.";
+          travis_terminate 0;
+        fi'
     script: cd frontend; yarn; yarn build
     deploy:
       provider: s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,11 @@ jobs:
     script: cd backend; yarn postgraphql-local & cd ../frontend; yarn; yarn get-schema; yarn test
   - stage: Deploy Backend to AWS
     before_script: 
-      - 'if [ -z "$AWS_ACCESS_KEY_ID" ]; then 
-          travis_terminate 1;
+      - 'if [ -z "$AWS_ACCESS_KEY_ID" ]; then
+          tput bold;
+          echo "AWS Credentials not set. Skipping deployment.";
+          tput sgr0;
+          travis_terminate 0;
         else
           npm install -g serverless;
         fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ jobs:
     script: cd backend; yarn postgraphql-local & cd ../frontend; yarn; yarn get-schema;
       yarn test
   - stage: Deploy Backend to AWS
-    allow_failure: ${[ -z "$AWS_ACCESS_KEY_ID" ] && echo true || echo false}
+    # allow_failure: ${[ -z "$AWS_ACCESS_KEY_ID" ] && echo true || echo false}
+    allow_failure: true
     before_script: npm install -g serverless
     script: cd backend; yarn; yarn rebuild-and-deploy
   - stage: Test backend against AWS endpoint

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,29 +11,29 @@ jobs:
     before_script: cd backend; yarn; yarn init-local-db; yarn local-drop-rebuild
     script: cd backend; yarn postgraphql-local & yarn test
   - stage: Test Frontend Locally
-      before_script: cd backend; yarn; yarn init-local-db; yarn local-drop-rebuild;
-      script: cd backend; yarn postgraphql-local & cd ../frontend; yarn; yarn get-schema; yarn test
+    before_script: cd backend; yarn; yarn init-local-db; yarn local-drop-rebuild;
+    script: cd backend; yarn postgraphql-local & cd ../frontend; yarn; yarn get-schema; yarn test
   - stage: Deploy Backend to AWS
-      before_script: 
-        - 'if [ -z "$AWS_ACCESS_KEY_ID" ]; then 
-            travis_terminate 1;
-          else
-            npm install -g serverless;
-          fi'
-      script: cd backend; yarn; yarn rebuild-and-deploy
+    before_script: 
+      - 'if [ -z "$AWS_ACCESS_KEY_ID" ]; then 
+          travis_terminate 1;
+        else
+          npm install -g serverless;
+        fi'
+    script: cd backend; yarn; yarn rebuild-and-deploy
   - stage: Test backend against AWS endpoint
-      before_script: npm install -g serverless
-      script: cd backend; yarn; yarn test-on-aws
-      after_script: cd backend; yarn; yarn rebuild-and-deploy
+    before_script: npm install -g serverless
+    script: cd backend; yarn; yarn test-on-aws
+    after_script: cd backend; yarn; yarn rebuild-and-deploy
   - stage: Deploy frontend to s3
-      script: cd frontend; yarn; yarn build
-      deploy:
-        provider: s3
-        access_key_id: "$AWS_ACCESS_KEY_ID"
-        secret_access_key: "$AWS_SECRET_ACCESS_KEY"
-        bucket: "$S3_BUCKET"
-        skip_cleanup: true
-        local_dir: build
-        acl: public_read
-        on:
-          all_branches: true
+    script: cd frontend; yarn; yarn build
+    deploy:
+      provider: s3
+      access_key_id: "$AWS_ACCESS_KEY_ID"
+      secret_access_key: "$AWS_SECRET_ACCESS_KEY"
+      bucket: "$S3_BUCKET"
+      skip_cleanup: true
+      local_dir: build
+      acl: public_read
+      on:
+        all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,7 @@ jobs:
     script: cd backend; yarn postgraphql-local & cd ../frontend; yarn; yarn get-schema;
       yarn test
   - stage: Deploy Backend to AWS
-    before_script: skip
-    before_script: npm install -g serverless
+    before_script: echo $AWS_ACCESS_KEY_ID; npm install -g serverless
     script: cd backend; yarn; yarn rebuild-and-deploy
   - stage: Test backend against AWS endpoint
     before_script: npm install -g serverless

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ jobs:
     script: cd backend; yarn postgraphql-local & cd ../frontend; yarn; yarn get-schema;
       yarn test
   - stage: Deploy Backend to AWS
-    before_script: echo $AWS_ACCESS_KEY_ID; npm install -g serverless
+    allow_failure: ${[ -z "$AWS_ACCESS_KEY_ID" ] && echo true || echo false}
+    before_script: npm install -g serverless
     script: cd backend; yarn; yarn rebuild-and-deploy
   - stage: Test backend against AWS endpoint
     before_script: npm install -g serverless


### PR DESCRIPTION
There are going to be branches that we don't want to set up AWS deployments for, but we still want to be able to use Travis to ensure the tests pass. I was hoping there would be a way to actually skip the steps conditionally, but that has not been implemented as a part of Travis build stages as of now. In the meantime, I updated the deployment related stages to check for AWS credentials and exit as passing if they aren't set.