### PR TITLE
Add tests around filtering users in allUsers query

### DIFF
--- a/backend/populateDB/schema.sql
+++ b/backend/populateDB/schema.sql
@@ -311,6 +311,27 @@ $$ language plpgsql strict security definer;
 
 comment on function floods.reactivate_user(integer, text, text, text) is 'Reactivates a user and creates an account.';
 
+-- Create function to search users
+-- TODO: plainto_tsquery probably won't do everything we need, so we'll need to implement something else to form a valid tsquery for search on the frontend
+create function floods.search_users(
+  search text
+) returns setof floods.user as $$
+  select resultuser
+  from (select
+      u as resultuser,
+      to_tsvector(u.first_name) ||
+      to_tsvector(u.last_name) ||
+      to_tsvector(c.name) as document
+    from 
+      floods.user u,
+      floods.community c
+    where
+      u.community_id = c.id) user_search
+  where user_search.document @@ plainto_tsquery(search);
+$$ language sql stable security definer;
+
+comment on function floods.search_users(text) is 'Searches users.';
+
 -- Create function to update status
 -- TODO: Figure out how to make reason and duration dynamic
 create function floods.new_status_update(
@@ -749,6 +770,9 @@ grant execute on function floods.authenticate(text, text) to floods_anonymous;
 
 -- Allow all users to get the latest status of a crossing
 grant execute on function floods.crossing_latest_status(floods.crossing) to floods_anonymous;
+
+-- Allow all users to search users
+grant execute on function floods.search_users(text) to floods_anonymous;
 
 -- Allow community admins and up to register new users
 -- NOTE: Extra logic around permissions in function

--- a/backend/src/__snapshots__/search.users.test.js.snap
+++ b/backend/src/__snapshots__/search.users.test.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`When searching users should search by first name correctly 1`] = `
+Array [
+  Object {
+    "id": 1,
+  },
+]
+`;
+
+exports[`When searching users should search by last name correctly 1`] = `
+Array [
+  Object {
+    "id": 3,
+  },
+  Object {
+    "id": 5,
+  },
+]
+`;

--- a/backend/src/get.all.users.test.js
+++ b/backend/src/get.all.users.test.js
@@ -1,0 +1,42 @@
+import HttpTransport from 'lokka-transport-http';
+import Lokka from 'lokka';
+import { endpoint } from './endpoints';
+
+const anonLokka = new Lokka({transport: new HttpTransport(endpoint)});
+const communityOne = { communityId: 1 };
+const communityTwo = { communityId: 2 };
+
+describe('When getting users', () => {
+  it('should get all users', async () => {
+    const response = await anonLokka.send(`
+      query($communityId:Int) {
+        allUsers(condition: {communityId: $communityId}) {
+          nodes {
+            communityId
+          }
+        }
+      }
+    `,{});
+
+    expect(response.allUsers.nodes).toContainEqual(communityOne);
+    expect(response.allUsers.nodes).toContainEqual(communityTwo);    
+  });
+
+  it('should get only the users in a specified community', async () => {
+    const response = await anonLokka.send(`
+      query($communityId:Int) {
+        allUsers(condition: {communityId: $communityId}) {
+          nodes {
+            communityId
+          }
+        }
+      }
+    `,
+    {
+      communityId: 2
+    });
+
+    expect(response.allUsers.nodes).not.toContainEqual(communityOne);
+    expect(response.allUsers.nodes).toContainEqual(communityTwo);    
+  });
+});

--- a/backend/src/search.users.test.js
+++ b/backend/src/search.users.test.js
@@ -1,0 +1,59 @@
+import HttpTransport from 'lokka-transport-http';
+import Lokka from 'lokka';
+import { endpoint } from './endpoints';
+
+const anonLokka = new Lokka({transport: new HttpTransport(endpoint)});
+
+describe('When searching users', () => {
+  it('should search by community name correctly', async () => {
+    const response = await anonLokka.send(`
+      query($communityName:String) {
+        searchUsers(search: $communityName) {
+          nodes {
+            communityId
+          }
+        }
+      }
+    `,
+    {
+      communityName: "texas"
+    });
+
+    expect(response.searchUsers.nodes).toContainEqual({ communityId: 1 });
+    expect(response.searchUsers.nodes).not.toContainEqual({ communityId: 2 });    
+  });
+
+  it('should search by first name correctly', async () => {
+    const response = await anonLokka.send(`
+      query($firstName:String) {
+        searchUsers(search: $firstName) {
+          nodes {
+            id
+          }
+        }
+      }
+    `,
+    {
+      firstName: "super"
+    });
+
+    expect(response.searchUsers.nodes).toMatchSnapshot();    
+  });
+
+  it('should search by last name correctly', async () => {
+    const response = await anonLokka.send(`
+      query($lastName:String) {
+        searchUsers(search: $lastName) {
+          nodes {
+            id
+          }
+        }
+      }
+    `,
+    {
+      lastName: "editor"
+    });
+
+    expect(response.searchUsers.nodes).toMatchSnapshot();    
+  });
+});


### PR DESCRIPTION
In order to implement filtering for the user table on the admin dash, we will need to send filter data into the GraphQL query. Before implementing this on the frontend, I decided to write a few backend tests to ensure the filtering is working correctly.