### PR TITLE
Update search users function to filter by community

### DIFF
--- a/backend/populateDB/schema.sql
+++ b/backend/populateDB/schema.sql
@@ -319,7 +319,8 @@ comment on function floods.reactivate_user(integer, text, text, text) is 'Reacti
 -- Create function to search users
 -- TODO: plainto_tsquery probably won't do everything we need, so we'll need to implement something else to form a valid tsquery for search on the frontend
 create function floods.search_users(
-  search text
+  search text,
+  community integer default null
 ) returns setof floods.user as $$
   select resultuser
   from (select
@@ -331,11 +332,13 @@ create function floods.search_users(
       floods.user u,
       floods.community c
     where
-      u.community_id = c.id) user_search
+      u.community_id = c.id and
+      (community is null or community = u.community_id)
+  ) user_search
   where user_search.document @@ plainto_tsquery(search);
 $$ language sql stable security definer;
 
-comment on function floods.search_users(text) is 'Searches users.';
+comment on function floods.search_users(text, integer) is 'Searches users.';
 
 -- Create function to update status
 -- TODO: Figure out how to make reason and duration dynamic
@@ -791,7 +794,7 @@ grant select on table floods.community_crossing to floods_anonymous;
 grant execute on function floods.authenticate(text, text) to floods_anonymous;
 
 -- Allow all users to search users
-grant execute on function floods.search_users(text) to floods_anonymous;
+grant execute on function floods.search_users(text, integer) to floods_anonymous;
 
 -- Allow community admins and up to register new users
 -- NOTE: Extra logic around permissions in function

--- a/backend/populateDB/schema.sql
+++ b/backend/populateDB/schema.sql
@@ -319,7 +319,7 @@ comment on function floods.reactivate_user(integer, text, text, text) is 'Reacti
 -- Create function to search users
 -- TODO: plainto_tsquery probably won't do everything we need, so we'll need to implement something else to form a valid tsquery for search on the frontend
 create function floods.search_users(
-  search text,
+  search text default null,
   community integer default null
 ) returns setof floods.user as $$
   select resultuser
@@ -335,7 +335,7 @@ create function floods.search_users(
       u.community_id = c.id and
       (community is null or community = u.community_id)
   ) user_search
-  where user_search.document @@ plainto_tsquery(search);
+  where search is null or user_search.document @@ plainto_tsquery(search);
 $$ language sql stable security definer;
 
 comment on function floods.search_users(text, integer) is 'Searches users.';

--- a/backend/src/__snapshots__/search.users.test.js.snap
+++ b/backend/src/__snapshots__/search.users.test.js.snap
@@ -1,5 +1,36 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`When searching users should filter by community correctly 1`] = `
+Array [
+  Object {
+    "id": 4,
+  },
+]
+`;
+
+exports[`When searching users should return all users when search string is null 1`] = `
+Array [
+  Object {
+    "id": 1,
+  },
+  Object {
+    "id": 2,
+  },
+  Object {
+    "id": 3,
+  },
+  Object {
+    "id": 4,
+  },
+  Object {
+    "id": 5,
+  },
+  Object {
+    "id": 6,
+  },
+]
+`;
+
 exports[`When searching users should search by first name correctly 1`] = `
 Array [
   Object {

--- a/backend/src/__snapshots__/search.users.test.js.snap
+++ b/backend/src/__snapshots__/search.users.test.js.snap
@@ -1,36 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`When searching users should filter by community correctly 1`] = `
-Array [
-  Object {
-    "id": 4,
-  },
-]
-`;
-
-exports[`When searching users should return all users when search string is null 1`] = `
-Array [
-  Object {
-    "id": 1,
-  },
-  Object {
-    "id": 2,
-  },
-  Object {
-    "id": 3,
-  },
-  Object {
-    "id": 4,
-  },
-  Object {
-    "id": 5,
-  },
-  Object {
-    "id": 6,
-  },
-]
-`;
-
 exports[`When searching users should search by first name correctly 1`] = `
 Array [
   Object {

--- a/backend/src/search.users.test.js
+++ b/backend/src/search.users.test.js
@@ -96,7 +96,7 @@ describe('When searching users', () => {
       query($community:Int) {
         searchUsers(community: $community) {
           nodes {
-            id
+            communityId
           }
         }
       }
@@ -105,6 +105,7 @@ describe('When searching users', () => {
       community: 2
     });
 
-    expect(response.searchUsers.nodes).toMatchSnapshot();    
+    expect(response.searchUsers.nodes).toContainEqual({ communityId: 2 });
+    expect(response.searchUsers.nodes).not.toContainEqual({ communityId: 1 });     
   });
 });

--- a/backend/src/search.users.test.js
+++ b/backend/src/search.users.test.js
@@ -56,4 +56,38 @@ describe('When searching users', () => {
 
     expect(response.searchUsers.nodes).toMatchSnapshot();    
   });
+
+    it('should return all users when search string is null', async () => {
+    const response = await anonLokka.send(`
+      query($nullSearch:String) {
+        searchUsers(search: $nullSearch) {
+          nodes {
+            id
+          }
+        }
+      }
+    `,
+    {
+      nullSearch: null
+    });
+
+    expect(response.searchUsers.nodes).toMatchSnapshot();    
+  });
+
+  it('should filter by community correctly', async () => {
+    const response = await anonLokka.send(`
+      query($community:Int) {
+        searchUsers(community: $community) {
+          nodes {
+            id
+          }
+        }
+      }
+    `,
+    {
+      community: 2
+    });
+
+    expect(response.searchUsers.nodes).toMatchSnapshot();    
+  });
 });

--- a/backend/src/search.users.test.js
+++ b/backend/src/search.users.test.js
@@ -57,7 +57,24 @@ describe('When searching users', () => {
     expect(response.searchUsers.nodes).toMatchSnapshot();    
   });
 
-    it('should return all users when search string is null', async () => {
+  it('should return nothing when search string doesnt match anything', async () => {
+    const response = await anonLokka.send(`
+      query($unmatchedSearch:String) {
+        searchUsers(search: $unmatchedSearch) {
+          nodes {
+            id
+          }
+        }
+      }
+    `,
+    {
+      unmatchedSearch: "abcdefghijklmnopqrstuvwxyz"
+    });
+
+    expect(response.searchUsers.nodes.length).toEqual(0);    
+  });
+
+  it('should return all users when search string is null', async () => {
     const response = await anonLokka.send(`
       query($nullSearch:String) {
         searchUsers(search: $nullSearch) {
@@ -71,7 +88,7 @@ describe('When searching users', () => {
       nullSearch: null
     });
 
-    expect(response.searchUsers.nodes).toMatchSnapshot();    
+    expect(response.searchUsers.nodes.length).not.toEqual(0);    
   });
 
   it('should filter by community correctly', async () => {


### PR DESCRIPTION
In order to get the manage users page working correctly, I updated the search users function by adding a community parameter. I also updated it to return all users filtered by community (or not) when the search parameter is unused.