### PR TITLE
Community admins can only delete crossings that aren't in other communities

### DIFF
--- a/backend/populateDB/schema.sql
+++ b/backend/populateDB/schema.sql
@@ -557,7 +557,12 @@ begin
   if current_setting('jwt.claims.role') != 'floods_super_admin' then
     -- and we are a community admin
     if current_setting('jwt.claims.role') = 'floods_community_admin' then
-      -- and we're trying to delete a user in a different community
+      -- and we're trying to delete a crossing that belongs to multiple communities
+      if (array_length(crossing_to_delete.community_ids, 1) > 1) then
+        raise exception 'Community administrators cannot delete crossings that belong to multiple communities';
+      end if;
+
+      -- and we're trying to delete a crossing in a different community
       if (array_position(crossing_to_delete.community_ids, current_setting('jwt.claims.community_id')::integer) is null) then
         raise exception 'Community administrators can only delete crossings in their community';
       end if;

--- a/frontend/src/components/Dashboard/CrossingDetailPage/CrossingDetails.js
+++ b/frontend/src/components/Dashboard/CrossingDetailPage/CrossingDetails.js
@@ -332,7 +332,9 @@ class CrossingDetails extends Component {
               >Save</button>
             </div>
           ) : (
-            crossing.active && currentUser.role !== 'floods_community_editor' && (
+            crossing.active &&
+            currentUser.role !== 'floods_community_editor' &&
+            crossingCommunities.length === 1 && (
             <div className="CrossingDetails__buttons flexcontainer">
               <button 
                 className="button button--plaintext color-highlight"


### PR DESCRIPTION
* Update backend to prevent deleting crossings in multiple communites
* Update frontend to hide delete button when crossing is in multiple communities
* resolves #112