### PR TITLE
Improve sidebar nearby crossing performance

### DIFF
--- a/frontend/src/components/Shared/CrossingMapPage/CrossingMapSidebar.js
+++ b/frontend/src/components/Shared/CrossingMapPage/CrossingMapSidebar.js
@@ -31,6 +31,7 @@ class CrossingMapSidebar extends Component {
       searchFocused: false,
       showNearby: true,
       showHistory: false,
+      nearbyCrossings: [],
     };
   }
 
@@ -41,6 +42,32 @@ class CrossingMapSidebar extends Component {
         showNearby: true,
         showHistory: false,
       });
+    }
+
+    // If we have a new map center, different crossings, or different visibility, update nearby crossings
+    if (
+      this.props.center !== nextProps.center ||
+      this.props.showOpen !== nextProps.showOpen ||
+      this.props.showClosed !== nextProps.showClosed ||
+      this.props.showCaution !== nextProps.showCaution ||
+      this.props.showClosed !== nextProps.showClosed ||
+      this.props.openCrossings !== nextProps.openCrossings ||
+      this.props.closedCrossings !== nextProps.closedCrossings ||
+      this.props.cautionCrossings !== nextProps.cautionCrossings ||
+      this.props.longtermCrossings !== nextProps.longtermCrossings
+    ) {
+      const nearbyCrossings = this.getNearbyCrossings(
+        nextProps.center,
+        nextProps.openCrossings,
+        nextProps.closedCrossings,
+        nextProps.cautionCrossings,
+        nextProps.longtermCrossings,
+        nextProps.showOpen,
+        nextProps.showClosed,
+        nextProps.showCaution,
+        nextProps.showLongterm,
+      );
+      this.setState({ nearbyCrossings: nearbyCrossings });
     }
   }
 
@@ -72,19 +99,17 @@ class CrossingMapSidebar extends Component {
     }
   };
 
-  getNearbyCrossings = () => {
-    const {
-      openCrossings,
-      closedCrossings,
-      cautionCrossings,
-      longtermCrossings,
-      showOpen,
-      showClosed,
-      showCaution,
-      showLongterm,
-      center,
-    } = this.props;
-
+  getNearbyCrossings = (
+    center,
+    openCrossings,
+    closedCrossings,
+    cautionCrossings,
+    longtermCrossings,
+    showOpen,
+    showClosed,
+    showCaution,
+    showLongterm,
+  ) => {
     let nearbyCrossings = [];
 
     if (showOpen && openCrossings) nearbyCrossings.push(...openCrossings);
@@ -124,7 +149,7 @@ class CrossingMapSidebar extends Component {
       setSelectedCommunity,
     } = this.props;
 
-    const nearbyCrossings = this.getNearbyCrossings();
+    const { nearbyCrossings } = this.state;
 
     return (
       <div className="CrossingMapSidebar__overlay-container">

--- a/frontend/src/components/Shared/CrossingMapPage/CrossingMapSidebar.js
+++ b/frontend/src/components/Shared/CrossingMapPage/CrossingMapSidebar.js
@@ -51,29 +51,10 @@ class CrossingMapSidebar extends Component {
       this.props.showClosed !== nextProps.showClosed ||
       this.props.showCaution !== nextProps.showCaution ||
       this.props.showClosed !== nextProps.showClosed ||
-      (this.props.openCrossings && !nextProps.openCrossings) ||
-      (!this.props.openCrossings && nextProps.openCrossings) ||
-      (this.props.closedCrossings && !nextProps.closedCrossings) ||
-      (!this.props.closedCrossings && nextProps.closedCrossings) ||
-      (this.props.cautionCrossings && !nextProps.cautionCrossings) ||
-      (!this.props.cautionCrossings && nextProps.cautionCrossings) ||
-      (this.props.longtermCrossings && !nextProps.longtermCrossings) ||
-      (!this.props.longtermCrossings && nextProps.longtermCrossings) ||
-      (this.props.openCrossings &&
-        nextProps.openCrossings &&
-        this.props.openCrossings.length !== nextProps.openCrossings.length) ||
-      (this.props.closedCrossings &&
-        nextProps.closedCrossings &&
-        this.props.closedCrossings.length !==
-          nextProps.closedCrossings.length) ||
-      (this.props.cautionCrossings &&
-        nextProps.cautionCrossings &&
-        this.props.cautionCrossings.length !==
-          nextProps.cautionCrossings.length) ||
-      (this.props.longtermCrossings &&
-        nextProps.longtermCrossings &&
-        this.props.longtermCrossings.length !==
-          nextProps.longtermCrossings.length)
+      this.props.openCrossings !== nextProps.openCrossings ||
+      this.props.closedCrossings !== nextProps.closedCrossings ||
+      this.props.cautionCrossings !== nextProps.cautionCrossings ||
+      this.props.longtermCrossings !== nextProps.longtermCrossings
     ) {
       const nearbyCrossings = this.getNearbyCrossings(
         nextProps.center,

--- a/frontend/src/components/Shared/CrossingMapPage/CrossingMapSidebar.js
+++ b/frontend/src/components/Shared/CrossingMapPage/CrossingMapSidebar.js
@@ -51,10 +51,29 @@ class CrossingMapSidebar extends Component {
       this.props.showClosed !== nextProps.showClosed ||
       this.props.showCaution !== nextProps.showCaution ||
       this.props.showClosed !== nextProps.showClosed ||
-      this.props.openCrossings !== nextProps.openCrossings ||
-      this.props.closedCrossings !== nextProps.closedCrossings ||
-      this.props.cautionCrossings !== nextProps.cautionCrossings ||
-      this.props.longtermCrossings !== nextProps.longtermCrossings
+      (this.props.openCrossings && !nextProps.openCrossings) ||
+      (!this.props.openCrossings && nextProps.openCrossings) ||
+      (this.props.closedCrossings && !nextProps.closedCrossings) ||
+      (!this.props.closedCrossings && nextProps.closedCrossings) ||
+      (this.props.cautionCrossings && !nextProps.cautionCrossings) ||
+      (!this.props.cautionCrossings && nextProps.cautionCrossings) ||
+      (this.props.longtermCrossings && !nextProps.longtermCrossings) ||
+      (!this.props.longtermCrossings && nextProps.longtermCrossings) ||
+      (this.props.openCrossings &&
+        nextProps.openCrossings &&
+        this.props.openCrossings.length !== nextProps.openCrossings.length) ||
+      (this.props.closedCrossings &&
+        nextProps.closedCrossings &&
+        this.props.closedCrossings.length !==
+          nextProps.closedCrossings.length) ||
+      (this.props.cautionCrossings &&
+        nextProps.cautionCrossings &&
+        this.props.cautionCrossings.length !==
+          nextProps.cautionCrossings.length) ||
+      (this.props.longtermCrossings &&
+        nextProps.longtermCrossings &&
+        this.props.longtermCrossings.length !==
+          nextProps.longtermCrossings.length)
     ) {
       const nearbyCrossings = this.getNearbyCrossings(
         nextProps.center,


### PR DESCRIPTION
In order to increase performance when rendering nearby crossings in the sidebar I moved the sort out of the render function.