### PR TITLE
Added eslint ignores for setting mapbox style to a string

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,11 +46,10 @@
     "start-js": "NODE_PATH=src react-scripts start",
     "start": "npm-run-all -p watch-css start-js",
     "start-local": "REACT_APP_GRAPHQL_ENDPOINT='http://localhost:5000/graphql' REACT_APP_XML_ENDPOINT='http://localhost:5000/xml' REACT_APP_EMAIL_ENDPOINT='http://localhost:5000/email/reset' yarn run start",
-    "validate-map-style": "node src/Map/style/scripts/validate.js",
     "build-css": "node-sass-chokidar --include-path ./src src/ -o src/",
     "watch-css": "yarn run build-css && node-sass-chokidar --include-path ./src src/ -o src/ --watch --recursive",
     "get-schema": "./src/stories/schema/getSchema.sh",
-    "build": "yarn build-map-style-json; yarn build-css; NODE_PATH=src react-scripts build",
+    "build": "yarn build-css; NODE_PATH=src react-scripts build",
     "test": "yarn build-css; NODE_PATH=src react-scripts test --env=jsdom",
     "eject": "react-scripts eject",
     "storybook": "NODE_PATH=src start-storybook -p 9001 -c .storybook & yarn watch-css"

--- a/frontend/src/components/Shared/Map/AddCrossingMap.js
+++ b/frontend/src/components/Shared/Map/AddCrossingMap.js
@@ -18,6 +18,7 @@ class AddCrossingMap extends Component {
     return (
       <Map
         className="CrossingStaticMap"
+        // eslint-disable-next-line
         style="mapbox://styles/croweatx/cjeynr3z01k492so57s8lo34o"
         center={crossingCoordinates}
         onStyleLoad={this.onStyleLoad}

--- a/frontend/src/components/Shared/Map/CrossingMap.js
+++ b/frontend/src/components/Shared/Map/CrossingMap.js
@@ -240,6 +240,7 @@ class CrossingMap extends React.Component {
     return (
       <Map
         onStyleLoad={this.onMapboxStyleLoad}
+        // eslint-disable-next-line
         style="mapbox://styles/croweatx/cjeynr3z01k492so57s8lo34o"
         containerStyle={{
           height: this.props.mapHeight,

--- a/frontend/src/components/Shared/Map/CrossingStaticMap.js
+++ b/frontend/src/components/Shared/Map/CrossingStaticMap.js
@@ -23,6 +23,7 @@ class CrossingStaticMap extends Component {
       <Map
         className="CrossingStaticMap"
         center={coordinates}
+        // eslint-disable-next-line
         style="mapbox://styles/croweatx/cjeynr3z01k492so57s8lo34o"
         onStyleLoad={this.onStyleLoad}
       >


### PR DESCRIPTION
instead of an object

The warnings are treated as errors on build.

I've created an issue #208 to prevent this type of surprise in the future