### PR TITLE
Don't build after test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
 - 8
 before_script: yarn;
 script: yarn test;
+before_deploy: yarn build;
 deploy:
   provider: s3
   access_key_id: "$AWS_ACCESS_KEY_ID"
@@ -11,7 +12,6 @@ deploy:
   skip_cleanup: true
   local_dir: build
   acl: public_read
-  script: yarn build;
   on:
     all_branches: true
     condition: "$AWS_ACCESS_KEY_ID"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
 - 8
 before_script: yarn;
-script: yarn test && yarn build;
+script: yarn test;
 deploy:
   provider: s3
   access_key_id: "$AWS_ACCESS_KEY_ID"
@@ -11,6 +11,7 @@ deploy:
   skip_cleanup: true
   local_dir: build
   acl: public_read
+  script: yarn build;
   on:
     all_branches: true
     condition: "$AWS_ACCESS_KEY_ID"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "watch-css": "yarn run build-css && node-sass-chokidar --include-path ./src src/ -o src/ --watch --recursive",
     "get-schema": "./src/stories/schema/getSchema.sh",
     "build": "yarn build-css; NODE_PATH=src react-scripts build",
-    "test": "yarn build-css; NODE_PATH=src react-scripts test --env=jsdom",
+    "test": "eslint --max-warnings 0 src && yarn build-css && NODE_PATH=src react-scripts test --env=jsdom",
     "eject": "react-scripts eject",
     "storybook": "NODE_PATH=src start-storybook -p 9001 -c .storybook & yarn watch-css"
   },

--- a/src/stories/__snapshots__/storyshots.test.js.snap
+++ b/src/stories/__snapshots__/storyshots.test.js.snap
@@ -34,7 +34,7 @@ exports[`Storyshots Crossing Details Small Width 1`] = `
           <span
             className="italic light gray--50"
           >
-            at city hall
+            605 Spurlock Valley · West Lake Hills, TX 78746
           </span>
         </div>
       </div>

--- a/src/stories/crossingDetails.js
+++ b/src/stories/crossingDetails.js
@@ -8,7 +8,6 @@ const crossing = {
   description: 'E of Intersection w/ Clifford',
   humanAddress: '605 Spurlock Valley \u00b7 West Lake Hills, TX 78746',
   geojson: '{"type":"Point","coordinates":[-97.768,30.267]}',
-  humanAddress: 'at city hall',
   humanCoordinates: '30°16\'1.200"N 97°46\'4.800"W',
   active: true,
   communityCrossingsByCrossingId: {

--- a/src/stories/userList.js
+++ b/src/stories/userList.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withApolloProvider } from 'storybook-addon-apollo-graphql';
-import { graphql } from 'react-apollo';
-import gql from 'graphql-tag';
 import UserList from 'components/Dashboard/ManageUsersPage/UserList';
 import schema from 'stories/schema/schema';
 


### PR DESCRIPTION
We added build step to testing because build runs eslint and treats warnings as errors.

Instead of running the full build on every test, just run the eslint part.